### PR TITLE
Fix exam page failing due to corrupted localStorage data

### DIFF
--- a/src/contexts/ExamContext.tsx
+++ b/src/contexts/ExamContext.tsx
@@ -206,17 +206,41 @@ export const ExamProvider: React.FC<{ children: React.ReactNode }> = ({ children
   // Load data from localStorage on initialization
   const [subjects, setSubjects] = useState<Subject[]>(() => {
     const stored = localStorage.getItem('examranger_subjects');
-    return stored ? JSON.parse(stored) : MOCK_SUBJECTS;
+    if (stored) {
+      try {
+        return JSON.parse(stored) as Subject[];
+      } catch (error) {
+        console.error('Failed to parse stored subjects:', error);
+        localStorage.removeItem('examranger_subjects');
+      }
+    }
+    return MOCK_SUBJECTS;
   });
-  
+
   const [exams, setExams] = useState<Exam[]>(() => {
     const stored = localStorage.getItem('examranger_exams');
-    return stored ? JSON.parse(stored) : MOCK_EXAMS;
+    if (stored) {
+      try {
+        return JSON.parse(stored) as Exam[];
+      } catch (error) {
+        console.error('Failed to parse stored exams:', error);
+        localStorage.removeItem('examranger_exams');
+      }
+    }
+    return MOCK_EXAMS;
   });
-  
+
   const [results, setResults] = useState<ExamResult[]>(() => {
     const stored = localStorage.getItem('examranger_results');
-    return stored ? JSON.parse(stored) : MOCK_RESULTS;
+    if (stored) {
+      try {
+        return JSON.parse(stored) as ExamResult[];
+      } catch (error) {
+        console.error('Failed to parse stored results:', error);
+        localStorage.removeItem('examranger_results');
+      }
+    }
+    return MOCK_RESULTS;
   });
   
   const [activeExam, setActiveExam] = useState<Exam | null>(null);
@@ -237,8 +261,8 @@ export const ExamProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, [results]);
 
   // Get user results
-  const userResults = results.sort((a, b) => 
-    new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime()
+  const userResults = [...results].sort(
+    (a, b) => new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime()
   );
 
   // Get all subjects
@@ -471,8 +495,11 @@ export const ExamProvider: React.FC<{ children: React.ReactNode }> = ({ children
   // Get user results
   const getUserResults = (userId: string) => {
     return results
-      .filter(result => result.userId === userId)
-      .sort((a, b) => new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime());
+      .filter((result) => result.userId === userId)
+      .sort(
+        (a, b) =>
+          new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime()
+      );
   };
 
   // Get rankings for a specific exam


### PR DESCRIPTION
## Summary
- Guard ExamContext against malformed data in localStorage
- Preserve existing exam results state when sorting

## Testing
- `npm run lint` *(fails: Unexpected any errors, require() import)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2aa50dc832a8f3bdeae756f715b